### PR TITLE
Fix typo for json in HTTPError exception

### DIFF
--- a/pypowerbi/groups.py
+++ b/pypowerbi/groups.py
@@ -55,7 +55,7 @@ class Groups:
 
         # 200 is the only successful code, raise an exception on any other response code
         if response.status_code != 200:
-            raise HTTPError(response, f'Get Groups request returned http error: {response.josn()}')
+            raise HTTPError(response, f'Get Groups request returned http error: {response.json()}')
 
         return self.groups_from_get_groups_response(response)
 


### PR DESCRIPTION
Noticed this typo when I didn't have group permissions set correctly.