### PR TITLE
Add OData filters to groups.get_groups()

### DIFF
--- a/pypowerbi/groups.py
+++ b/pypowerbi/groups.py
@@ -45,8 +45,8 @@ class Groups:
         """
         Fetches all groups that the client has access to
         :param filter_str: OData filter string to filter results
-        :param top: OData top parameter to limit to the top n results
-        :param skip: OData skip parameter to skip the first n results
+        :param top: int > 0, OData top parameter to limit to the top n results
+        :param skip: int > 0,  OData skip parameter to skip the first n results
         :return: list
             The list of groups
         """

--- a/pypowerbi/groups.py
+++ b/pypowerbi/groups.py
@@ -1,6 +1,7 @@
 # -*- coding: future_fstrings -*-
 import requests
 import json
+import urllib.parse
 
 from requests.exceptions import HTTPError
 from .group import Group
@@ -40,14 +41,35 @@ class Groups:
 
         return False
 
-    def get_groups(self):
+    def get_groups(self, filter_str=None, top=None, skip=None):
         """
         Fetches all groups that the client has access to
+        :param filter_str: OData filter string to filter results
+        :param top: OData top parameter to limit to the top n results
+        :param skip: OData skip parameter to skip the first n results
         :return: list
             The list of groups
         """
+        query_parameters = []
+
+        if filter_str:
+            query_parameters.append(f'$filter={urllib.parse.quote(filter_str)}')
+
+        if top:
+            stripped_top = json.dumps(top).strip('"')
+            query_parameters.append(f'$top={urllib.parse.quote(stripped_top)}')
+
+        if skip:
+            stripped_skip = json.dumps(skip).strip('"')
+            query_parameters.append(f'$skip={urllib.parse.quote(stripped_skip)}')
+
         # form the url
         url = f'{self.base_url}/{self.groups_snippet}'
+
+        # add query parameters to url if any
+        if len(query_parameters) > 0:
+            url += f'?{str.join("&", query_parameters)}'
+
         # form the headers
         headers = self.client.auth_header
         # get the response


### PR DESCRIPTION
Hi Chris,

This pull request adds the OData filters 'filter', 'top', and 'skip' to the groups.get_groups() method. This makes it possible to filter, and slice collections of powerBI workspaces (a.k.a. groups). The implementation is largely a port of the logic from the official .NET SDK for PowerBI to Python. That logic can be found here:

https://github.com/microsoft/PowerBI-CSharp/blob/f4cdb0c9e80366fee6f4f2044cc5b532b5b11123/sdk/PowerBI.Api/Source/GroupsOperations.cs#L84

I have tested the logic in my own project, and it worked as expected. I'd love to hear your feedback. In case this looks acceptable, I could make more contributions, as I'm currently using pypowerbi in a project of mine. I will be on holidays the coming two weeks, but afterwards I can make changes if needed.