### PR TITLE
Add create_group to groups module

### DIFF
--- a/pypowerbi/groups.py
+++ b/pypowerbi/groups.py
@@ -18,6 +18,44 @@ class Groups:
         self.client = client
         self.base_url = f'{self.client.api_url}/{self.client.api_version_snippet}/{self.client.api_myorg_snippet}'
 
+    def create_group(self, name, workspace_v2=False):
+        """Creates a new workspace
+
+        :param name: The name of the new group to create
+        :param workspace_v2: Create a workspace V2
+        :return: Group
+            The newly created group
+        """
+        if name is None or name == "":
+            raise ValueError("Group name cannot be empty or None")
+
+        body = {'name': name}
+
+        # create url
+        url = f'{self.base_url}/{self.groups_snippet}'
+
+        uri_parameters = []
+
+        if workspace_v2:
+            stripped_workspace_v2 = json.dumps(workspace_v2).strip('"')
+            uri_parameters.append(f'workspaceV2={urllib.parse.quote(stripped_workspace_v2)}')
+
+        # add query parameters to url if any
+        if len(uri_parameters) > 0:
+            url += f'?{str.join("&", uri_parameters)}'
+
+        # form the headers
+        headers = self.client.auth_header
+
+        # get the response
+        response = requests.post(url, headers=headers, json=body)
+
+        # 200 is the only successful code, raise an exception on any other response code
+        if response.status_code != 200:
+            raise HTTPError(f'Add group request returned the following http error: {response.json()}')
+
+        return self.groups_from_get_groups_response(response)[0]
+
     def count(self):
         """
         Evaluates the number of groups that the client has access to

--- a/pypowerbi/groups.py
+++ b/pypowerbi/groups.py
@@ -26,9 +26,11 @@ class Groups:
         :return: Group
             The newly created group
         """
+        # validate request body
         if name is None or name == "":
             raise ValueError("Group name cannot be empty or None")
 
+        # define request body
         body = {'name': name}
 
         # create url

--- a/pypowerbi/groups.py
+++ b/pypowerbi/groups.py
@@ -56,7 +56,19 @@ class Groups:
         if response.status_code != 200:
             raise HTTPError(f'Add group request returned the following http error: {response.json()}')
 
-        return self.groups_from_get_groups_response(response)[0]
+        return self.create_group_from_create_group_response(response)
+
+    @staticmethod
+    def create_group_from_create_group_response(response):
+        """Creates a Group object from the response to a create_group call
+
+        :param response:
+            The http response object
+        :return:
+            Group object describing the newly created group
+        """
+        group_dict = json.loads(response.text)
+        return Group.from_dict(group_dict)
 
     def count(self):
         """


### PR DESCRIPTION
Hello Chris,

Here's my second contribution to pypowerbi. This time I added a create_group method to the groups module. In other words, a method to create new workspaces. The code is again based on the C# code from the .NET SDK. More specifically this method:

https://github.com/microsoft/PowerBI-CSharp/blob/3bd4ee2d8c54b4d1960c97d1766722805da5f771/sdk/PowerBI.Api/Source/GroupsOperations.cs#L247

I did ran into the issue that [REST API docs](https://docs.microsoft.com/en-us/rest/api/power-bi/groups/creategroup) for this method seemed outdated, as the API did not return the typical wrapper object with a value key, as specified in the docs, but instead returned a flat object response like this:
```json
{
  "@odata.context":"http://wabi-europe-north-b-redirect.analysis.windows.net/v1.0/myorg/$metadata#groups/$entity",
  "id":"some-guid",
  "isReadOnly":false,
  "isOnDedicatedCapacity":false,
  "name":"name-of-workspace"
}
```
Hence I added an additional static helper method that could parse this type of response appropriately. The code has again been tested in my own codebase, and worked well.

I'd love to hear your feedback, and expect to add another pull request soon for [AddGroupUser](https://docs.microsoft.com/en-us/rest/api/power-bi/groups/addgroupuser).