### PR TITLE
Add create_group and add_group_user to groups module

### DIFF
--- a/pypowerbi/group_user.py
+++ b/pypowerbi/group_user.py
@@ -1,0 +1,64 @@
+from enum import Enum
+
+
+class GroupUserAccessRight(Enum):
+    NONE = 'None'
+    MEMBER = 'Member'
+    ADMIN = 'Admin'
+    CONTRIBUTOR = 'Contributor'
+    VIEWER = 'Viewer'
+
+
+class PrincipalType(Enum):
+    USER = "User"
+    GROUP = "Group"
+    APP = "App"
+
+
+class GroupUser:
+    def __init__(
+        self,
+        group_user_access_right,
+        email_address="",
+        display_name="",
+        identifier="",
+        principal_type=None
+    ):
+        """Constructs a GroupUser object
+
+        :param group_user_access_right: Enum GroupUserAccessRight - The access right to assign to the GroupUser
+        :param email_address: str - E-mail address of the user if principal type is user
+        :param display_name: str - Display name of the principal
+        :param identifier: str - Identifier of the principal
+        :param principal_type: Enum PrincipalType - The principal type
+        """
+        self.group_user_access_right = group_user_access_right
+        self.email_address = email_address
+        self.display_name = display_name
+        self.identifier = identifier
+        self.principal_type = principal_type
+
+    def as_set_values_dict(self):
+        """Convert GroupUser object to dict with only values that are actually set. This dict can be used for
+        groups.add_group_user requests.
+
+        :return: Dict with object attributes in camelCase as keys, and attribute values as values.
+        """
+        group_user_dict = dict()
+
+        if self.group_user_access_right:
+            group_user_dict["groupUserAccessRight"] = self.group_user_access_right.value
+
+        if self.email_address:
+            group_user_dict["emailAddress"] = self.email_address
+
+        if self.display_name:
+            group_user_dict["displayName"] = self.display_name
+
+        if self.identifier:
+            group_user_dict["identifier"] = self.identifier
+
+        if self.principal_type:
+            group_user_dict["principalType"] = self.principal_type.value
+
+        return group_user_dict

--- a/pypowerbi/group_user.py
+++ b/pypowerbi/group_user.py
@@ -16,6 +16,12 @@ class PrincipalType(Enum):
 
 
 class GroupUser:
+    group_user_access_right_key = 'groupUserAccessRight'
+    email_address_key = 'emailAddress'
+    display_name_key = 'displayName'
+    identifier_key = 'identifier'
+    principal_type_key = 'principalType'
+
     def __init__(
         self,
         group_user_access_right,
@@ -47,18 +53,18 @@ class GroupUser:
         group_user_dict = dict()
 
         if self.group_user_access_right:
-            group_user_dict["groupUserAccessRight"] = self.group_user_access_right.value
+            group_user_dict[self.group_user_access_right_key] = self.group_user_access_right.value
 
         if self.email_address:
-            group_user_dict["emailAddress"] = self.email_address
+            group_user_dict[self.email_address_key] = self.email_address
 
         if self.display_name:
-            group_user_dict["displayName"] = self.display_name
+            group_user_dict[self.display_name_key] = self.display_name
 
         if self.identifier:
-            group_user_dict["identifier"] = self.identifier
+            group_user_dict[self.identifier_key] = self.identifier
 
         if self.principal_type:
-            group_user_dict["principalType"] = self.principal_type.value
+            group_user_dict[self.principal_type_key] = self.principal_type.value
 
         return group_user_dict

--- a/pypowerbi/groups.py
+++ b/pypowerbi/groups.py
@@ -18,6 +18,44 @@ class Groups:
         self.client = client
         self.base_url = f'{self.client.api_url}/{self.client.api_version_snippet}/{self.client.api_myorg_snippet}'
 
+    def create_group(self, name, workspace_v2=False):
+        """Creates a new workspace
+
+        :param name: The name of the new group to create
+        :param workspace_v2: Create a workspace V2
+        :return: Group
+            The newly created group
+        """
+        if name is None or name == "":
+            raise ValueError("Group name cannot be empty or None")
+
+        body = {'name': name}
+
+        # create url
+        url = f'{self.base_url}/{self.groups_snippet}'
+
+        uri_parameters = []
+
+        if workspace_v2:
+            stripped_workspace_v2 = json.dumps(workspace_v2).strip('"')
+            uri_parameters.append(f'workspaceV2={urllib.parse.quote(stripped_workspace_v2)}')
+
+        # add query parameters to url if any
+        if len(uri_parameters) > 0:
+            url += f'?{str.join("&", uri_parameters)}'
+
+        # form the headers
+        headers = self.client.auth_header
+
+        # get the response
+        response = requests.post(url, headers=headers, json=body)
+
+        # 200 is the only successful code, raise an exception on any other response code
+        if response.status_code != 200:
+            raise HTTPError(f'Add group request returned the following http error: {response.json()}')
+
+        return self.groups_from_get_groups_response(response)[0]
+
     def count(self):
         """
         Evaluates the number of groups that the client has access to

--- a/pypowerbi/groups.py
+++ b/pypowerbi/groups.py
@@ -26,9 +26,11 @@ class Groups:
         :return: Group
             The newly created group
         """
+        # validate request body
         if name is None or name == "":
             raise ValueError("Group name cannot be empty or None")
 
+        # define request body
         body = {'name': name}
 
         # create url

--- a/pypowerbi/groups.py
+++ b/pypowerbi/groups.py
@@ -56,7 +56,19 @@ class Groups:
         if response.status_code != 200:
             raise HTTPError(f'Add group request returned the following http error: {response.json()}')
 
-        return self.groups_from_get_groups_response(response)[0]
+        return self.create_group_from_create_group_response(response)
+
+    @staticmethod
+    def create_group_from_create_group_response(response):
+        """Creates a Group object from the response to a create_group call
+
+        :param response:
+            The http response object
+        :return:
+            Group object describing the newly created group
+        """
+        group_dict = json.loads(response.text)
+        return Group.from_dict(group_dict)
 
     def count(self):
         """


### PR DESCRIPTION
Hi Chris,

This pull request adds two additional methods to the groups module:
- [create_group](https://docs.microsoft.com/en-us/rest/api/power-bi/groups/addgroupuser) (allows the creation of new workspaces)
- [add_group user](https://docs.microsoft.com/en-us/rest/api/power-bi/groups/addgroupuser) (allows adding users to workspaces)

For add_group_user three models have also been added in a new group_user module:
- GroupUser
- PrincipalType
- GroupUserAccessRight

The code has been based on the C# code found here:
- [create_group](https://github.com/microsoft/PowerBI-CSharp/blob/3bd4ee2d8c54b4d1960c97d1766722805da5f771/sdk/PowerBI.Api/Source/GroupsOperations.cs#L247)
- [add_group_user](https://github.com/microsoft/PowerBI-CSharp/blob/3bd4ee2d8c54b4d1960c97d1766722805da5f771/sdk/PowerBI.Api/Source/GroupsOperations.cs#L668)
- [GroupUser](https://github.com/microsoft/PowerBI-CSharp/blob/master/sdk/PowerBI.Api/Source/Models/GroupUser.cs)
- [PrincipalType](https://github.com/microsoft/PowerBI-CSharp/blob/master/sdk/PowerBI.Api/Source/Models/PrincipalType.cs)
- [GroupUserAccessRight](https://github.com/microsoft/PowerBI-CSharp/blob/master/sdk/PowerBI.Api/Source/Models/GroupUserAccessRight.cs)

**Implementation Notes**
1. I noticed the response for `create_group` is lacking the wrapper object with the `value` key of which [the docs](https://docs.microsoft.com/en-us/rest/api/power-bi/groups/creategroup#examples) claim it should be returned. Instead the REST API returned a flat object like the one below. Hence, I needed to add an additional helper method to parse the response correctly.
```json
{
  "@odata.context":"http://wabi-europe-north-b-redirect.analysis.windows.net/v1.0/myorg/$metadata#groups/$entity",
  "id":"some-guid",
  "isReadOnly":false,
  "isOnDedicatedCapacity":false,
  "name":"name-of-workspace"
}
```
2. I have implemented the `PrincipleType` and `GroupUserAccessRight` classes using the `Enum` class that was introduced in Python 3.4. This seemed like the fastest way to implement it, though I was not sure whether backwards compatibility ought to be maintained with Python 2.7 or earlier Python 3 versions. In case backwards-compatibility is a concern we could consider picking one of the solutions found [here](https://stackoverflow.com/questions/36932/how-can-i-represent-an-enum-in-python)