### PR TITLE
Add gateways module

### DIFF
--- a/pypowerbi/__init__.py
+++ b/pypowerbi/__init__.py
@@ -1,7 +1,3 @@
-import future_fstrings
-
-future_fstrings.register()
-
 from .client import *
 from .dataset import *
 from .datasets import *

--- a/pypowerbi/__init__.py
+++ b/pypowerbi/__init__.py
@@ -1,3 +1,7 @@
+import future_fstrings
+
+future_fstrings.register()
+
 from .client import *
 from .dataset import *
 from .datasets import *

--- a/pypowerbi/__init__.py
+++ b/pypowerbi/__init__.py
@@ -5,3 +5,5 @@ from .report import *
 from .reports import *
 from .imports import *
 from .groups import *
+from .gateways import *
+from .gateway import *

--- a/pypowerbi/base.py
+++ b/pypowerbi/base.py
@@ -1,0 +1,10 @@
+import abc
+from typing import Dict, Union
+
+
+class Deserializable(metaclass=abc.ABCMeta):
+    """Interface to ensure operations modules need fewer methods to turn responses into objects"""
+    @classmethod
+    @abc.abstractmethod
+    def from_dict(cls, dictionary: Dict[str, Union[str, Dict[str, str]]]):
+        pass

--- a/pypowerbi/client.py
+++ b/pypowerbi/client.py
@@ -8,6 +8,7 @@ from .reports import Reports
 from .datasets import Datasets
 from .imports import Imports
 from .groups import Groups
+from .gateways import Gateways
 from .activity_logs import ActivityLogs
 
 
@@ -60,6 +61,7 @@ class PowerBIClient:
         self.reports = Reports(self)
         self.imports = Imports(self)
         self.groups = Groups(self)
+        self.gateways = Gateways(self)
         self.activity_logs = ActivityLogs(self)
 
     @property

--- a/pypowerbi/credentials.py
+++ b/pypowerbi/credentials.py
@@ -1,0 +1,92 @@
+from typing import Optional, Dict, List, Union
+import json
+
+from pypowerbi import CredentialType
+
+
+class CredentialsBase:
+    CREDENTIAL_TYPE: Optional[CredentialType] = None
+    credential_data_key = "credentialData"
+
+    def __init__(self):
+        self.credential_data: Dict[str, Union[str, List[Dict[str, str]]]] = {
+            self.credential_data_key: []
+        }
+
+    def add_credential_data(self, key, value):
+        self.credential_data[self.credential_data_key].append(
+            {"name": key, "value": value}
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.credential_data, separators=(',', ':'))\
+            .replace('\\\\', '\\')
+
+
+class UsernamePasswordCredentials(CredentialsBase):
+    username_key = "username"
+    password_key = "password"
+
+    def __init__(self, username: str, password: str):
+        super().__init__()
+
+        if not username:
+            raise ValueError("An empty string is not a valid username!")
+        if not password:
+            raise ValueError("An empty string is not a valid password!")
+
+        self.username = username
+        self.password = password
+
+        super().add_credential_data(self.username_key, username)
+        super().add_credential_data(self.password_key, password)
+
+
+class AnonymousCredentials(CredentialsBase):
+    CREDENTIAL_TYPE = CredentialType.ANONYMOUS
+
+    def __init__(self):
+        super().__init__()
+        self.credential_data[self.credential_data_key] = ""
+
+
+class BasicCredentials(UsernamePasswordCredentials):
+    CREDENTIAL_TYPE = CredentialType.BASIC
+
+    def __init__(self, username: str, password: str):
+        super().__init__(username, password)
+
+
+class KeyCredentials(CredentialsBase):
+    CREDENTIAL_TYPE = CredentialType.KEY
+    key_key = "key"
+
+    def __init__(self, key: str):
+        super().__init__()
+
+        if not key:
+            raise ValueError("An empty string is not a valid key!")
+
+        self.key = key
+
+        super().add_credential_data(self.key_key, key)
+
+
+class OAuth2Credentials(CredentialsBase):
+    CREDENTIAL_TYPE = CredentialType.OAUTH2
+    access_token_key = "accessToken"
+
+    def __init__(self, access_token: str):
+        super().__init__()
+
+        if not access_token:
+            raise ValueError("An empty string is not a valid access token!")
+
+        super().add_credential_data(self.access_token_key, access_token)
+
+
+class WindowsCredentials(UsernamePasswordCredentials):
+    CREDENTIAL_TYPE = CredentialType.WINDOWS
+
+    def __init__(self, username: str, password: str):
+        super().__init__(username, password)

--- a/pypowerbi/credentials.py
+++ b/pypowerbi/credentials.py
@@ -49,12 +49,18 @@ class AnonymousCredentials(CredentialsBase):
         super().__init__()
         self.credential_data[self.credential_data_key] = ""
 
+    def __repr__(self) -> str:
+        return f'<AnonymousCredentials>'
+
 
 class BasicCredentials(UsernamePasswordCredentials):
     CREDENTIAL_TYPE = CredentialType.BASIC
 
     def __init__(self, username: str, password: str):
         super().__init__(username, password)
+
+    def __repr__(self) -> str:
+        return f'<BasicCredentials username={self.username}>'
 
 
 class KeyCredentials(CredentialsBase):
@@ -71,6 +77,9 @@ class KeyCredentials(CredentialsBase):
 
         super().add_credential_data(self.key_key, key)
 
+    def __repr__(self) -> str:
+        return f'<KeyCredentials>'
+
 
 class OAuth2Credentials(CredentialsBase):
     CREDENTIAL_TYPE = CredentialType.OAUTH2
@@ -84,9 +93,15 @@ class OAuth2Credentials(CredentialsBase):
 
         super().add_credential_data(self.access_token_key, access_token)
 
+    def __repr__(self) -> str:
+        return f'<OAuth2Credentials>'
+
 
 class WindowsCredentials(UsernamePasswordCredentials):
     CREDENTIAL_TYPE = CredentialType.WINDOWS
 
     def __init__(self, username: str, password: str):
         super().__init__(username, password)
+
+    def __repr__(self):
+        return f'<WindowsCredentials username={self.username}>'

--- a/pypowerbi/enums.py
+++ b/pypowerbi/enums.py
@@ -1,0 +1,34 @@
+# -*- coding: future_fstrings -*-
+
+from enum import Enum
+
+
+class GroupUserAccessRight(Enum):
+    NONE = 'None'
+    MEMBER = 'Member'
+    ADMIN = 'Admin'
+    CONTRIBUTOR = 'Contributor'
+    VIEWER = 'Viewer'
+
+
+class PrincipalType(Enum):
+    USER = "User"
+    GROUP = "Group"
+    APP = "App"
+
+
+class DatasourceUserAccessRight(Enum):
+    # Removes permission to access the datasource
+    NONE = 'None'
+    # Datasets owned by the user have read access to this datasource
+    READ = 'Read'
+    # The user can override the effective identity for PowerBI Embedded
+    READ_OVERRIDE_EFFECTIVE_IDENTITY = 'ReadOverrideEffectiveIdentity'
+
+
+class CredentialType(Enum):
+    ANONYMOUS = 'Anonymous'
+    BASIC = 'Basic'
+    KEY = 'Key'
+    OAUTH2 = 'OAuth2'
+    WINDOWS = 'Windows'

--- a/pypowerbi/enums.py
+++ b/pypowerbi/enums.py
@@ -32,3 +32,20 @@ class CredentialType(Enum):
     KEY = 'Key'
     OAUTH2 = 'OAuth2'
     WINDOWS = 'Windows'
+
+
+class EncryptedConnection(Enum):
+    ENCRYPTED = 'Encrypted'
+    NOT_ENCRYPTED = 'NotEncrypted'
+
+
+class EncryptionAlgorithm(Enum):
+    NONE = 'None'
+    RSA_OAEP = 'RSA-OAEP'
+
+
+class PrivacyLevel(Enum):
+    NONE = 'None'
+    PUBLIC = 'Public'
+    ORGANIZATIONAL = 'Organizational'
+    PRIVATE = 'Private'

--- a/pypowerbi/gateway.py
+++ b/pypowerbi/gateway.py
@@ -210,3 +210,6 @@ class DatasourceUser(Deserializable):
             else principal_type_value
 
         return cls(datasource_user_access_right, email_address, display_name, datasource_user_id, principal_type)
+
+    def __repr__(self) -> str:
+        return f'<DatasourceUser id={self.identifier} type={self.principal_type.name} display_name={self.display_name}>'

--- a/pypowerbi/gateway.py
+++ b/pypowerbi/gateway.py
@@ -1,8 +1,11 @@
 # -*- coding: future_fstrings -*-
+import json
+from enum import Enum
+
 
 class GatewayPublicKey:
-    exponent_key = "exponent"
-    modulus_key = "modulus"
+    exponent_key = 'exponent'
+    modulus_key = 'modulus'
 
     def __init__(self, exponent, modulus):
         """Constructs a GatewayPublicKey object
@@ -83,3 +86,73 @@ class Gateway:
 
     def __repr__(self):
         return f'<Gateway id={self.id} name={self.name}>'
+
+
+class CredentialType(Enum):
+    ANONYMOUS = 'Anonymous'
+    BASIC = 'Basic'
+    KEY = 'Key'
+    OAUTH2 = 'OAuth2'
+    WINDOWS = 'Windows'
+
+
+class GatewayDatasource:
+    gateway_datasource_id_key = 'id'
+    gateway_id_key = 'gatewayId'
+    credential_type_key = 'credentialType'
+    datasource_name_key = 'datasourceName'
+    datasource_type_key = 'datasourceType'
+    connection_details_key = 'connectionDetails'
+
+    def __init__(
+        self,
+        gateway_datasource_id,
+        gateway_id,
+        credential_type,
+        datasource_name,
+        datasource_type,
+        connection_details
+    ):
+        """Constructs a GatewayDatasource object
+
+        :param gateway_datasource_id: str - The unique id for this datasource
+        :param gateway_id: str - The associated gateway id
+        :param credential_type: CredentialType - Type of datasource credentials
+        :param datasource_name: str - The name of the datasource
+        :param datasource_type: str - The type of the datasource
+        :param connection_details: str - Connection details in json format
+        """
+        self.id = gateway_datasource_id
+        self.gateway_id = gateway_id
+        self.credential_type = credential_type
+        self.datasource_name = datasource_name
+        self.datasource_type = datasource_type
+        self.connection_details = connection_details
+
+    @classmethod
+    def from_dict(cls, dictionary):
+        """Constructs a GatewayDatasource object from a dict
+
+        :param dictionary: Dictionary describing the gatewayDatasource
+        :return: GatewayDatasource based on the dictionary
+        :rtype: GatewayDatasource
+        """
+        gateway_datasource_id = dictionary.get(cls.gateway_datasource_id_key)
+        if gateway_datasource_id is None:
+            raise RuntimeError("GatewayDatasource dictionary has no id key")
+
+        gateway_id = dictionary.get(cls.gateway_id_key)
+        # use round brackets below to access enum by value
+        credential_type = CredentialType(dictionary.get(cls.credential_type_key))
+        datasource_name = dictionary.get(cls.datasource_name_key)
+        datasource_type = dictionary.get(cls.datasource_type_key)
+        connection_details = json.dumps(dictionary.get(cls.connection_details_key))
+
+        return cls(
+            gateway_datasource_id,
+            gateway_id,
+            credential_type,
+            datasource_name,
+            datasource_type,
+            connection_details
+        )

--- a/pypowerbi/gateway.py
+++ b/pypowerbi/gateway.py
@@ -156,3 +156,6 @@ class GatewayDatasource:
             datasource_type,
             connection_details
         )
+
+    def __repr__(self):
+        return f'<GatewayDatasource id={self.id} name={self.datasource_name} type={self.datasource_type}>'

--- a/pypowerbi/gateway.py
+++ b/pypowerbi/gateway.py
@@ -1,6 +1,7 @@
 # -*- coding: future_fstrings -*-
 import json
 from typing import Dict, Union, Optional
+
 from .base import Deserializable
 from .enums import CredentialType, DatasourceUserAccessRight, PrincipalType, EncryptedConnection, EncryptionAlgorithm, \
     PrivacyLevel
@@ -211,6 +212,25 @@ class DatasourceUser(Deserializable):
             else principal_type_value
 
         return cls(datasource_user_access_right, email_address, display_name, datasource_user_id, principal_type)
+
+    def as_set_values_dict(self) -> Dict[str, str]:
+        set_values_dict = dict()
+
+        set_values_dict[self.datasource_access_right_key] = self.datasource_access_right.value
+
+        if self.email_address:
+            set_values_dict[self.email_address_key] = self.email_address
+
+        if self.display_name:
+            set_values_dict[self.display_name_key] = self.display_name
+
+        if self.identifier:
+            set_values_dict[self.identifier_key] = self.identifier
+
+        if self.principal_type:
+            set_values_dict[self.principal_type_key] = self.principal_type.value
+
+        return set_values_dict
 
     def __repr__(self) -> str:
         return f'<DatasourceUser id={self.identifier} type={self.principal_type.name} display_name={self.display_name}>'

--- a/pypowerbi/gateway.py
+++ b/pypowerbi/gateway.py
@@ -275,8 +275,7 @@ class DatasourceConnectionDetails:
         # remove double quotes at start and end of str
         return json.dumps(json_dict) \
             .replace(r'": ', r'":') \
-            .replace('\\\\', '\\') \
-            [1:-1]
+            .replace('\\\\', '\\')
 
 
 class CredentialDetails:

--- a/pypowerbi/gateway.py
+++ b/pypowerbi/gateway.py
@@ -1,29 +1,35 @@
 # -*- coding: future_fstrings -*-
 import json
-from enum import Enum
+from typing import Dict, Union, Optional
+from .base import Deserializable
+from .enums import CredentialType, DatasourceUserAccessRight, PrincipalType
 
 
-class GatewayPublicKey:
+class GatewayPublicKey(Deserializable):
     exponent_key = 'exponent'
     modulus_key = 'modulus'
 
-    def __init__(self, exponent, modulus):
+    def __init__(
+            self,
+            exponent: str,
+            modulus: str
+    ):
         """Constructs a GatewayPublicKey object
 
-        :param exponent: str - the exponent of the public key
-        :param modulus: str - the modulus of the public key
+        :param exponent: The exponent of the public key
+        :param modulus: The modulus of the public key
         """
         self.exponent = exponent
         self.modulus = modulus
 
-    def as_dict(self):
+    def as_dict(self) -> Dict[str, str]:
         return {
             self.exponent_key: self.exponent,
             self.modulus_key: self.modulus
         }
 
     @classmethod
-    def from_dict(cls, dictionary):
+    def from_dict(cls, dictionary: Dict[str, str]) -> 'GatewayPublicKey':
         """Constructs a GatewayPublicKey from a dictionary
 
         :param dictionary: the dictionary describing the GatewayPublicKey
@@ -35,11 +41,11 @@ class GatewayPublicKey:
 
         return cls(exponent, modulus)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'<GatewayPublicKey exponent={self.exponent} modulus={self.modulus}>'
 
 
-class Gateway:
+class Gateway(Deserializable):
     id_key = 'id'
     name_key = 'name'
     type_key = 'type'
@@ -47,15 +53,23 @@ class Gateway:
     public_key_key = 'publicKey'
     status_key = 'gatewayStatus'
 
-    def __init__(self, gateway_id, name, gateway_type, gateway_annotation, public_key, status):
+    def __init__(
+            self,
+            gateway_id: str,
+            name: str,
+            gateway_type: str,
+            gateway_annotation: str,
+            public_key: GatewayPublicKey,
+            status: str
+    ):
         """Constructs a Gateway object
 
-        :param gateway_id: str - The gateway id
-        :param name: str - The gateway name
-        :param gateway_type: str - The gateway type
-        :param gateway_annotation: str - Gateway metadata in json format
-        :param public_key: GatewayPublicKey - The gateway public key
-        :param status: str - The gateway connectivity status
+        :param gateway_id: The gateway id
+        :param name: The gateway name
+        :param gateway_type: The gateway type
+        :param gateway_annotation: Gateway metadata in json format
+        :param public_key: The gateway public key
+        :param status: The gateway connectivity status
         """
         self.id = gateway_id
         self.name = name
@@ -65,7 +79,7 @@ class Gateway:
         self.status = status
 
     @classmethod
-    def from_dict(cls, dictionary):
+    def from_dict(cls, dictionary: Dict[str, Union[str, Dict[str, str]]]) -> 'Gateway':
         """Constructs a Gateway object from a dict
 
         :param dictionary: Dictionary describing the gateway
@@ -84,19 +98,11 @@ class Gateway:
 
         return cls(gateway_id, name, gateway_type, gateway_annotation, public_key, status)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'<Gateway id={self.id} name={self.name}>'
 
 
-class CredentialType(Enum):
-    ANONYMOUS = 'Anonymous'
-    BASIC = 'Basic'
-    KEY = 'Key'
-    OAUTH2 = 'OAuth2'
-    WINDOWS = 'Windows'
-
-
-class GatewayDatasource:
+class GatewayDatasource(Deserializable):
     gateway_datasource_id_key = 'id'
     gateway_id_key = 'gatewayId'
     credential_type_key = 'credentialType'
@@ -105,22 +111,22 @@ class GatewayDatasource:
     connection_details_key = 'connectionDetails'
 
     def __init__(
-        self,
-        gateway_datasource_id,
-        gateway_id,
-        credential_type,
-        datasource_name,
-        datasource_type,
-        connection_details
+            self,
+            gateway_datasource_id: str,
+            gateway_id: str,
+            credential_type: CredentialType,
+            datasource_name: str,
+            datasource_type: str,
+            connection_details: str
     ):
         """Constructs a GatewayDatasource object
 
-        :param gateway_datasource_id: str - The unique id for this datasource
-        :param gateway_id: str - The associated gateway id
-        :param credential_type: CredentialType - Type of datasource credentials
-        :param datasource_name: str - The name of the datasource
-        :param datasource_type: str - The type of the datasource
-        :param connection_details: str - Connection details in json format
+        :param gateway_datasource_id: The unique id for this datasource
+        :param gateway_id: The associated gateway id
+        :param credential_type: Type of datasource credentials
+        :param datasource_name: The name of the datasource
+        :param datasource_type: The type of the datasource
+        :param connection_details: Connection details in json format
         """
         self.id = gateway_datasource_id
         self.gateway_id = gateway_id
@@ -130,7 +136,7 @@ class GatewayDatasource:
         self.connection_details = connection_details
 
     @classmethod
-    def from_dict(cls, dictionary):
+    def from_dict(cls, dictionary: Dict[str, str]) -> 'GatewayDatasource':
         """Constructs a GatewayDatasource object from a dict
 
         :param dictionary: Dictionary describing the gatewayDatasource

--- a/pypowerbi/gateway.py
+++ b/pypowerbi/gateway.py
@@ -1,0 +1,85 @@
+# -*- coding: future_fstrings -*-
+
+class GatewayPublicKey:
+    exponent_key = "exponent"
+    modulus_key = "modulus"
+
+    def __init__(self, exponent, modulus):
+        """Constructs a GatewayPublicKey object
+
+        :param exponent: str - the exponent of the public key
+        :param modulus: str - the modulus of the public key
+        """
+        self.exponent = exponent
+        self.modulus = modulus
+
+    def as_dict(self):
+        return {
+            self.exponent_key: self.exponent,
+            self.modulus_key: self.modulus
+        }
+
+    @classmethod
+    def from_dict(cls, dictionary):
+        """Constructs a GatewayPublicKey from a dictionary
+
+        :param dictionary: the dictionary describing the GatewayPublicKey
+        :return: GatewayPublicKey based on the dictionary
+        :rtype: GatewayPublicKey
+        """
+        exponent = dictionary.get(cls.exponent_key)
+        modulus = dictionary.get(cls.modulus_key)
+
+        return cls(exponent, modulus)
+
+    def __repr__(self):
+        return f'<GatewayPublicKey exponent={self.exponent} modulus={self.modulus}>'
+
+
+class Gateway:
+    id_key = 'id'
+    name_key = 'name'
+    type_key = 'type'
+    gateway_annotation_key = 'gatewayAnnotation'
+    public_key_key = 'publicKey'
+    status_key = 'gatewayStatus'
+
+    def __init__(self, gateway_id, name, gateway_type, gateway_annotation, public_key, status):
+        """Constructs a Gateway object
+
+        :param gateway_id: str - The gateway id
+        :param name: str - The gateway name
+        :param gateway_type: str - The gateway type
+        :param gateway_annotation: str - Gateway metadata in json format
+        :param public_key: GatewayPublicKey - The gateway public key
+        :param status: str - The gateway connectivity status
+        """
+        self.id = gateway_id
+        self.name = name
+        self.type = gateway_type
+        self.gateway_annotation = gateway_annotation
+        self.public_key = public_key
+        self.status = status
+
+    @classmethod
+    def from_dict(cls, dictionary):
+        """Constructs a Gateway object from a dict
+
+        :param dictionary: Dictionary describing the gateway
+        :return: Gateway based on the dictionary
+        :rtype: Gateway
+        """
+        gateway_id = dictionary.get(cls.id_key)
+        if gateway_id is None:
+            raise RuntimeError("Gateway dictionary has no id key")
+
+        name = dictionary.get(cls.name_key)
+        gateway_type = dictionary.get(cls.type_key)
+        gateway_annotation = dictionary.get(cls.gateway_annotation_key)
+        public_key = GatewayPublicKey.from_dict(dictionary.get(cls.public_key_key))
+        status = dictionary.get(cls.status_key)
+
+        return cls(id, name, gateway_type, gateway_annotation, public_key, status)
+
+    def __repr__(self):
+        return f'<Gateway id={self.id} name={self.name}>'

--- a/pypowerbi/gateway.py
+++ b/pypowerbi/gateway.py
@@ -165,3 +165,48 @@ class GatewayDatasource(Deserializable):
 
     def __repr__(self):
         return f'<GatewayDatasource id={self.id} name={self.datasource_name} type={self.datasource_type}>'
+
+
+class DatasourceUser(Deserializable):
+    datasource_access_right_key = 'datasourceAccessRight'
+    email_address_key = 'emailAddress'
+    display_name_key = 'displayName'
+    identifier_key = 'identifier'
+    principal_type_key = 'principalType'
+
+    def __init__(
+        self,
+        datasource_access_right: DatasourceUserAccessRight,
+        email_address: str = "",
+        display_name: str = "",
+        identifier: str = "",
+        principal_type: Optional[PrincipalType] = None
+    ):
+        """Constructs a DataSourceUser object
+
+        :param datasource_access_right: The user access rights for the datasource
+        :param email_address: Email address of the user
+        :param display_name: Display name of the principal
+        :param identifier: Identifier of the principal
+        :param principal_type: The principal type
+        """
+        self.datasource_access_right = datasource_access_right
+        self.email_address = email_address
+        self.display_name = display_name
+        self.identifier = identifier
+        self.principal_type = principal_type
+
+    @classmethod
+    def from_dict(cls, dictionary: Dict[str, str]) -> 'DatasourceUser':
+        datasource_user_id = dictionary.get(cls.identifier_key)
+        if datasource_user_id is None:
+            raise RuntimeError("DatasourceUser dictionary has no identifier key")
+
+        datasource_user_access_right = DatasourceUserAccessRight(dictionary.get(cls.datasource_access_right_key))
+        email_address = dictionary.get(cls.email_address_key, "")
+        display_name = dictionary.get(cls.display_name_key, "")
+        principal_type_value = dictionary.get(cls.principal_type_key, None)
+        principal_type = PrincipalType(principal_type_value) if principal_type_value is not None \
+            else principal_type_value
+
+        return cls(datasource_user_access_right, email_address, display_name, datasource_user_id, principal_type)

--- a/pypowerbi/gateway.py
+++ b/pypowerbi/gateway.py
@@ -269,11 +269,11 @@ class DatasourceConnectionDetails:
         """
         json_dict = self.as_set_values_dict()
 
-        # dump twice to get double quotes escaped properly
+        # dump to json string
         # remove spaces between object keys and values
         # replace double backslashes with single slashes
         # remove double quotes at start and end of str
-        return json.dumps(json.dumps(json_dict)) \
+        return json.dumps(json_dict) \
             .replace(r'": ', r'":') \
             .replace('\\\\', '\\') \
             [1:-1]

--- a/pypowerbi/gateway.py
+++ b/pypowerbi/gateway.py
@@ -82,7 +82,7 @@ class Gateway:
         public_key = GatewayPublicKey.from_dict(dictionary.get(cls.public_key_key))
         status = dictionary.get(cls.status_key)
 
-        return cls(id, name, gateway_type, gateway_annotation, public_key, status)
+        return cls(gateway_id, name, gateway_type, gateway_annotation, public_key, status)
 
     def __repr__(self):
         return f'<Gateway id={self.id} name={self.name}>'

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -6,7 +6,6 @@ import json
 
 from requests.exceptions import HTTPError
 
-from . import PowerBIClient
 from .gateway import Gateway, GatewayDatasource, DatasourceUser
 from .base import Deserializable
 
@@ -20,7 +19,7 @@ class Gateways:
     # json keys
     odata_response_wrapper_key = 'value'
 
-    def __init__(self, client: PowerBIClient):
+    def __init__(self, client):
         self.client = client
         self.base_url = f'{self.client.api_url}/{self.client.api_version_snippet}/{self.client.api_myorg_snippet}'
 

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -188,8 +188,7 @@ class Gateways:
 
         if response.status_code != 200:
             # add datasource user requests return an empty body; get the error from headers instead
-            error_info = response.headers['x-powerbi-error-info']
-            raise HTTPError(f'Add group request returned the following http error: {error_info} with status code:'
+            raise HTTPError(f'Add group request returned the following http error: {response.json()} with status code:'
                             f' {response.status_code}')
 
         return None

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -194,7 +194,6 @@ class Gateways:
 
         return None
 
-
     @classmethod
     def _models_from_get_multiple_response(
         cls,

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -39,11 +39,7 @@ class Gateways:
         if response.status_code != 200:
             raise HTTPError(response, f'Get Gateways request returned http error: {response.json()}')
 
-        return self.gateways_from_get_gateways_response(response)
-
-    @classmethod
-    def gateways_from_get_gateways_response(cls, response):
-        """Creates a list of gateways from a http response object
+        return self._models_from_get_multiple_response(response, Gateway)
 
     def get_datasources(self, gateway_id: str) -> List[GatewayDatasource]:
         """Returns a list of datasources from the specified gateway
@@ -66,24 +62,30 @@ class Gateways:
         if response.status_code != 200:
             raise HTTPError(response, f'Get Gateway Datasources request returned http error: {response.json()}')
 
-        return self.datasources_from_get_datasources_response(response)
+        return self._models_from_get_multiple_response(response, GatewayDatasource)
 
     @classmethod
-    def datasources_from_get_datasources_response(cls, response):
-        """Creates a list of gateway datasources from a http response object
+    def _models_from_get_multiple_response(
+            cls,
+            response: requests.Response,
+            model_class: Type[Deserializable]
+    ) -> List[Any]:
+        """Creates a list of models from a http response object
 
         :param response:
             The http response object
+        :param model_class:
+            The model to transform the response items into
         :return: list
-            The list of gateway datasources
+            The list of model_class instances
         """
 
         # parse json response into a dict
         response_dict = json.loads(response.text)
 
         # Add parsed Gateway objects to list
-        gateway_datasources = []
+        items = []
         for entry in response_dict[cls.odata_response_wrapper_key]:
-            gateway_datasources.append(GatewayDatasource.from_dict(entry))
+            items.append(model_class.from_dict(entry))
 
-        return gateway_datasources
+        return items

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -139,7 +139,7 @@ class Gateways:
         self,
         gateway_id: str,
         datasource_id: str
-    ):
+    ) -> None:
         """Deletes the specified datasource from the specified gateway
 
         :param gateway_id: The gateway id
@@ -160,6 +160,40 @@ class Gateways:
             raise HTTPError(f'Delete Datasource request returned the following http error: {response.json()}')
 
         return None
+
+    def add_datasource_user(
+        self,
+        gateway_id: str,
+        datasource_id: str,
+        datasource_user: DatasourceUser
+    ) -> None:
+        """Grants or updates the permissions required to use the specified datasource for the specified user
+
+        :param gateway_id: The gateway id
+        :param datasource_id: The datasource id
+        :param datasource_user: The datasource user to add
+        """
+        # form the url
+        url = f'{self.base_url}/{self.gateways_snippet}/{gateway_id}/{self.datasources_snippet}/{datasource_id}/' \
+              f'{self.users_snippet}'
+
+        # define request body
+        body = datasource_user.as_set_values_dict()
+
+        # form the headers
+        headers = self.client.auth_header
+
+        # get the response
+        response = requests.post(url, headers=headers, json=body)
+
+        if response.status_code != 200:
+            # add datasource user requests return an empty body; get the error from headers instead
+            error_info = response.headers['x-powerbi-error-info']
+            raise HTTPError(f'Add group request returned the following http error: {error_info} with status code:'
+                            f' {response.status_code}')
+
+        return None
+
 
     @classmethod
     def _models_from_get_multiple_response(

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -1,9 +1,14 @@
 # -*- coding: future_fstrings -*-
+from typing import List, Type, Any
+
 import requests
 import json
 
 from requests.exceptions import HTTPError
-from .gateway import Gateway, GatewayDatasource
+
+from . import PowerBIClient
+from .gateway import Gateway, GatewayDatasource, DatasourceUser
+from .base import Deserializable
 
 
 class Gateways:
@@ -14,11 +19,11 @@ class Gateways:
     # json keys
     odata_response_wrapper_key = 'value'
 
-    def __init__(self, client):
+    def __init__(self, client: PowerBIClient):
         self.client = client
         self.base_url = f'{self.client.api_url}/{self.client.api_version_snippet}/{self.client.api_myorg_snippet}'
 
-    def get_gateways(self):
+    def get_gateways(self) -> List[Gateway]:
         """Fetches all gateways the user is an admin for"""
 
         # form the url
@@ -40,23 +45,7 @@ class Gateways:
     def gateways_from_get_gateways_response(cls, response):
         """Creates a list of gateways from a http response object
 
-        :param response:
-            The http response object
-        :return: list
-            The list of gateways
-        """
-
-        # parse json response into a dict
-        response_dict = json.loads(response.text)
-
-        # Add parsed Gateway objects to list
-        gateways = []
-        for entry in response_dict[cls.odata_response_wrapper_key]:
-            gateways.append(Gateway.from_dict(entry))
-
-        return gateways
-
-    def get_datasources(self, gateway_id):
+    def get_datasources(self, gateway_id: str) -> List[GatewayDatasource]:
         """Returns a list of datasources from the specified gateway
 
         :param gateway_id: The gateway id to return responses for

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -167,7 +167,9 @@ class Gateways:
         datasource_id: str,
         datasource_user: DatasourceUser
     ) -> None:
-        """Grants or updates the permissions required to use the specified datasource for the specified user
+        """Grants or updates the permissions required to use the specified datasource for the specified user. Note:
+        This method does not work with a service principal, only with a username password flow, for which the user
+        has given consent.
 
         :param gateway_id: The gateway id
         :param datasource_id: The datasource id

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -188,8 +188,8 @@ class Gateways:
 
         if response.status_code != 200:
             # add datasource user requests return an empty body; get the error from headers instead
-            raise HTTPError(f'Add group request returned the following http error: {response.json()} with status code:'
-                            f' {response.status_code}')
+            raise HTTPError(f'Add datasource user request returned the following http error: {response.json()} '
+                            f'with status code: {response.status_code}')
 
         return None
 

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -1,0 +1,57 @@
+# -*- coding: future_fstrings -*-
+import requests
+import json
+
+from requests.exceptions import HTTPError
+from .gateway import Gateway
+
+
+class Gateways:
+    # url snippets
+    gateways_snippet = 'gateways'
+
+    # json keys
+    get_gateways_value_key = 'value'
+
+    def __init__(self, client):
+        self.client = client
+        self.base_url = f'{self.client.api_url}/{self.client.api_version_snippet}/{self.client.api_myorg_snippet}'
+
+    def get_gateways(self):
+        """Fetches all gateways the user is an admin for"""
+
+        # form the url
+        url = f'{self.base_url}/{self.gateways_snippet}'
+
+        # form the headers
+        headers = self.client.auth_header
+
+        # get the response
+        response = requests.get(url, headers=headers)
+
+        # 200 is the only successful code, raise an exception on any other response code
+        if response.status_code != 200:
+            raise HTTPError(response, f'Get Gateways request returned http error: {response.json()}')
+
+        return self.gateways_from_get_gateways_response(response)
+
+
+    @classmethod
+    def gateways_from_get_gateways_response(cls, response):
+        """Creates a list of gateways from a http response object
+
+        :param response:
+            The http response object
+        :return: list
+            The list of gateways
+        """
+
+        # parse json response into a dict
+        response_dict = json.loads(response.text)
+
+        # Add parsed Gateway objects to list
+        gateways = []
+        for entry in response_dict[cls.get_gateways_value_key]:
+            gateways.append(Gateway.from_dict(entry))
+
+        return gateways

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -15,6 +15,7 @@ class Gateways:
     # url snippets
     gateways_snippet = 'gateways'
     datasources_snippet = 'datasources'
+    users_snippet = 'users'
 
     # json keys
     odata_response_wrapper_key = 'value'
@@ -63,6 +64,28 @@ class Gateways:
             raise HTTPError(response, f'Get Gateway Datasources request returned http error: {response.json()}')
 
         return self._models_from_get_multiple_response(response, GatewayDatasource)
+
+    def get_datasource_users(self, gateway_id: str, datasource_id: str) -> List[DatasourceUser]:
+        """Returns a list of users who have access to the specified datasource
+
+        :param gateway_id: The gateway id
+        :param datasource_id: The datasource id
+        """
+        # form the url
+        url = f'{self.base_url}/{self.gateways_snippet}/{gateway_id}' \
+              f'/{self.datasources_snippet}/{datasource_id}/{self.users_snippet}'
+
+        # form the headers
+        headers = self.client.auth_header
+
+        # get the response
+        response = requests.get(url, headers=headers)
+
+        # 200 is the only successful code, raise an exception on any other response code
+        if response.status_code != 200:
+            raise HTTPError(response, f'Get Datasource Users request returned http error: {response.json()}')
+
+        return self._models_from_get_multiple_response(response, DatasourceUser)
 
     @classmethod
     def _models_from_get_multiple_response(

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -118,7 +118,7 @@ class Gateways:
         :param datasource_to_gateway_request: Request describing the datasource to be created
         """
         # form the url
-        url = f"{self.base_url}/{self.gateways_snippet}/{gateway_id}/{self.datasources_snippet}"
+        url = f'{self.base_url}/{self.gateways_snippet}/{gateway_id}/{self.datasources_snippet}'
 
         # define request body
         body = datasource_to_gateway_request.to_dict()
@@ -134,6 +134,32 @@ class Gateways:
             raise HTTPError(f'Create Datasource request returned the following http error: {response.json()}')
 
         return self._model_from_get_one_response(response, GatewayDatasource)
+
+    def delete_datasource(
+        self,
+        gateway_id: str,
+        datasource_id: str
+    ):
+        """Deletes the specified datasource from the specified gateway
+
+        :param gateway_id: The gateway id
+        :param datasource_id: The datasource id
+        :return: None
+        """
+        # form the url
+        url = f'{self.base_url}/{self.gateways_snippet}/{gateway_id}/{self.datasources_snippet}/{datasource_id}'
+
+        # form the headers
+        headers = self.client.auth_header
+
+        # get the response
+        response = requests.delete(url, headers=headers)
+
+        # 200 is the only successful code, raise an exception on any other response code
+        if response.status_code != 200:
+            raise HTTPError(f'Delete Datasource request returned the following http error: {response.json()}')
+
+        return None
 
     @classmethod
     def _models_from_get_multiple_response(

--- a/pypowerbi/gateways.py
+++ b/pypowerbi/gateways.py
@@ -41,6 +41,27 @@ class Gateways:
 
         return self._models_from_get_multiple_response(response, Gateway)
 
+    def get_gateway(self, gateway_id: str) -> Gateway:
+        """Return the specified gateway
+
+        :param gateway_id: The gateway id
+        :return: The gateway
+        """
+        # form the url
+        url = f'{self.base_url}/{self.gateways_snippet}/{gateway_id}'
+
+        # form the headers
+        headers = self.client.auth_header
+
+        # get the response
+        response = requests.get(url, headers=headers)
+
+        # 200 is the only successful code, raise an exception on any other response code
+        if response.status_code != 200:
+            raise HTTPError(response, f'Get Gateway request returned http error: {response.json()}')
+
+        return self._model_from_get_one_response(response, Gateway)
+
     def get_datasources(self, gateway_id: str) -> List[GatewayDatasource]:
         """Returns a list of datasources from the specified gateway
 

--- a/pypowerbi/group_user.py
+++ b/pypowerbi/group_user.py
@@ -1,20 +1,4 @@
-from enum import Enum
-
-
-class GroupUserAccessRight(Enum):
-    NONE = 'None'
-    MEMBER = 'Member'
-    ADMIN = 'Admin'
-    CONTRIBUTOR = 'Contributor'
-    VIEWER = 'Viewer'
-
-
-class PrincipalType(Enum):
-    USER = "User"
-    GROUP = "Group"
-    APP = "App"
-
-
+# -*- coding: future_fstrings -*-
 class GroupUser:
     group_user_access_right_key = 'groupUserAccessRight'
     email_address_key = 'emailAddress'

--- a/pypowerbi/tests/credentials_tests.py
+++ b/pypowerbi/tests/credentials_tests.py
@@ -1,0 +1,96 @@
+from unittest import TestCase
+
+from pypowerbi import CredentialType
+from pypowerbi.credentials import AnonymousCredentials, BasicCredentials, KeyCredentials, OAuth2Credentials, \
+    WindowsCredentials
+
+
+# The following tests are based on the examples found here:
+# https://docs.microsoft.com/en-us/rest/api/power-bi/gateways/updatedatasource#examples
+class CredentialsTestCase(TestCase):
+    def test_anonymous_credentials(self):
+        anonymous_credentials = AnonymousCredentials()
+
+        expected = r'{"credentialData":""}'
+        actual = anonymous_credentials.to_json()
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(
+            CredentialType.ANONYMOUS,
+            anonymous_credentials.CREDENTIAL_TYPE
+        )
+
+    def test_basic_credentials(self):
+        basic_credentials = BasicCredentials("john", "*****")
+
+        expected = r'{"credentialData":[{"name":"username","value":"john"},{"name":"password","value":"*****"}]}'
+        actual = basic_credentials.to_json()
+
+        with self.assertRaises(ValueError):
+            # empty username
+            BasicCredentials("", "myPassword")
+
+        with self.assertRaises(ValueError):
+            # empty password
+            BasicCredentials("myUsername", "")
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(
+            CredentialType.BASIC,
+            basic_credentials.CREDENTIAL_TYPE
+        )
+
+    def test_key_credentials(self):
+        key_credentials = KeyCredentials("ec....LA=")
+
+        expected = r'{"credentialData":[{"name":"key","value":"ec....LA="}]}'
+        actual = key_credentials.to_json()
+
+        with self.assertRaises(ValueError):
+            # empty key
+            KeyCredentials("")
+
+        self.assertEqual(expected, actual)
+
+        self.assertEqual(
+            CredentialType.KEY,
+            key_credentials.CREDENTIAL_TYPE
+        )
+
+    def test_o_auth_2_credentials(self):
+        o_auth_2_credentials = OAuth2Credentials("eyJ0....fwtQ")
+
+        expected = r'{"credentialData":[{"name":"accessToken","value":"eyJ0....fwtQ"}]}'
+        actual = o_auth_2_credentials.to_json()
+
+        with self.assertRaises(ValueError):
+            # empty access token
+            OAuth2Credentials("")
+
+        self.assertEqual(expected, actual)
+
+        self.assertEqual(
+            CredentialType.OAUTH2,
+            o_auth_2_credentials.CREDENTIAL_TYPE
+        )
+
+    def test_windows_credentials(self):
+        windows_credentials = WindowsCredentials(r'contoso\\john', "*****")
+
+        expected = r'{"credentialData":[{"name":"username","value":"contoso\\john"},' \
+                   r'{"name":"password","value":"*****"}]}'
+        actual = windows_credentials.to_json()
+
+        with self.assertRaises(ValueError):
+            # empty username
+            WindowsCredentials("", "myPassword")
+
+        with self.assertRaises(ValueError):
+            # empty password
+            WindowsCredentials("myUsername", "")
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(
+            CredentialType.WINDOWS,
+            windows_credentials.CREDENTIAL_TYPE
+        )

--- a/pypowerbi/tests/utils_tests.py
+++ b/pypowerbi/tests/utils_tests.py
@@ -69,26 +69,26 @@ class UtilsTests(TestCase):
     # https://docs.microsoft.com/en-us/rest/api/power-bi/gateways/updatedatasource#examples
     def test_get_anonymous_credentials(self):
         actual = CredentialsBuilder.get_anonymous_credentials()
-        expected = r'{\"credentialData\":\"\"}'
+        expected = r'{"credentialData":""}'
         self.assertEqual(expected, actual)
 
     def test_get_basic_credentials(self):
         actual = CredentialsBuilder.get_basic_credentials("john", "*****")
-        expected = r'{\"credentialData\":[{\"name\":\"username\", \"value\":\"john\"}, {\"name\":\"password\", \"value\":\"*****\"}]}'
+        expected = r'{"credentialData":[{"name":"username","value":"john"},{"name":"password","value":"*****"}]}'
         self.assertEqual(expected, actual)
 
     def test_get_key_credentials(self):
         actual = CredentialsBuilder.get_key_credentials("ec....LA=")
-        expected = r'{\"credentialData\":[{\"name\":\"key\", \"value\":\"ec....LA=\"}]}'
+        expected = r'{"credentialData":[{"name":"key","value":"ec....LA="}]}'
         self.assertEqual(expected, actual)
 
     def test_get_o_auth_2_credentials(self):
         actual = CredentialsBuilder.get_o_auth_2_credentials("eyJ0....fwtQ")
-        expected = r'{\"credentialData\":[{\"name\":\"accessToken\", \"value\":\"eyJ0....fwtQ\"}]}'
+        expected = r'{"credentialData":[{"name":"accessToken","value":"eyJ0....fwtQ"}]}'
         self.assertEqual(expected, actual)
 
     def test_get_windows_credentials(self):
-        actual = CredentialsBuilder.get_windows_credentials(r'contoso\john', "*****")
-        expected = r'{\"credentialData\":[{\"name\":\"username\", \"value\":\"contoso\\john\"}, {\"name\":\"password\", \"value\":\"*****\"}]}'
+        actual = CredentialsBuilder.get_windows_credentials(r'contoso\\john', "*****")
+        expected = r'{"credentialData":[{"name":"username","value":"contoso\\john"},{"name":"password","value":"*****"}]}'
 
         self.assertEqual(expected, actual)

--- a/pypowerbi/tests/utils_tests.py
+++ b/pypowerbi/tests/utils_tests.py
@@ -1,11 +1,11 @@
-# -*- coding: future_fstrings -*-
-
 import json
 from unittest import TestCase
 
 import datetime
 
 from pypowerbi import utils
+from pypowerbi.utils import CredentialsBuilder
+
 
 class UtilsTests(TestCase):
     def test_date_from_powerbi_str(self):
@@ -65,3 +65,30 @@ class UtilsTests(TestCase):
         for converted, target in zip(converted_list, target_list):
             self.assertEqual(converted, target)
 
+    # The following tests are based on the examples found here:
+    # https://docs.microsoft.com/en-us/rest/api/power-bi/gateways/updatedatasource#examples
+    def test_get_anonymous_credentials(self):
+        actual = CredentialsBuilder.get_anonymous_credentials()
+        expected = r'{\"credentialData\":\"\"}'
+        self.assertEqual(expected, actual)
+
+    def test_get_basic_credentials(self):
+        actual = CredentialsBuilder.get_basic_credentials("john", "*****")
+        expected = r'{\"credentialData\":[{\"name\":\"username\", \"value\":\"john\"}, {\"name\":\"password\", \"value\":\"*****\"}]}'
+        self.assertEqual(expected, actual)
+
+    def test_get_key_credentials(self):
+        actual = CredentialsBuilder.get_key_credentials("ec....LA=")
+        expected = r'{\"credentialData\":[{\"name\":\"key\", \"value\":\"ec....LA=\"}]}'
+        self.assertEqual(expected, actual)
+
+    def test_get_o_auth_2_credentials(self):
+        actual = CredentialsBuilder.get_o_auth_2_credentials("eyJ0....fwtQ")
+        expected = r'{\"credentialData\":[{\"name\":\"accessToken\", \"value\":\"eyJ0....fwtQ\"}]}'
+        self.assertEqual(expected, actual)
+
+    def test_get_windows_credentials(self):
+        actual = CredentialsBuilder.get_windows_credentials(r'contoso\john', "*****")
+        expected = r'{\"credentialData\":[{\"name\":\"username\", \"value\":\"contoso\\john\"}, {\"name\":\"password\", \"value\":\"*****\"}]}'
+
+        self.assertEqual(expected, actual)

--- a/pypowerbi/tests/utils_tests.py
+++ b/pypowerbi/tests/utils_tests.py
@@ -64,31 +64,3 @@ class UtilsTests(TestCase):
 
         for converted, target in zip(converted_list, target_list):
             self.assertEqual(converted, target)
-
-    # The following tests are based on the examples found here:
-    # https://docs.microsoft.com/en-us/rest/api/power-bi/gateways/updatedatasource#examples
-    def test_get_anonymous_credentials(self):
-        actual = CredentialsBuilder.get_anonymous_credentials()
-        expected = r'{"credentialData":""}'
-        self.assertEqual(expected, actual)
-
-    def test_get_basic_credentials(self):
-        actual = CredentialsBuilder.get_basic_credentials("john", "*****")
-        expected = r'{"credentialData":[{"name":"username","value":"john"},{"name":"password","value":"*****"}]}'
-        self.assertEqual(expected, actual)
-
-    def test_get_key_credentials(self):
-        actual = CredentialsBuilder.get_key_credentials("ec....LA=")
-        expected = r'{"credentialData":[{"name":"key","value":"ec....LA="}]}'
-        self.assertEqual(expected, actual)
-
-    def test_get_o_auth_2_credentials(self):
-        actual = CredentialsBuilder.get_o_auth_2_credentials("eyJ0....fwtQ")
-        expected = r'{"credentialData":[{"name":"accessToken","value":"eyJ0....fwtQ"}]}'
-        self.assertEqual(expected, actual)
-
-    def test_get_windows_credentials(self):
-        actual = CredentialsBuilder.get_windows_credentials(r'contoso\\john', "*****")
-        expected = r'{"credentialData":[{"name":"username","value":"contoso\\john"},{"name":"password","value":"*****"}]}'
-
-        self.assertEqual(expected, actual)

--- a/pypowerbi/utils.py
+++ b/pypowerbi/utils.py
@@ -55,7 +55,7 @@ def convert_datetime_fields(list_of_dicts, fields_to_convert):
 class CredentialsBuilder:
     """
     This class can be used to quickly generate credentials strings for use in a gateway.CredentialDetails object.
-    Which methods to use depends on Which enums.CredentialType is passed along with the credentials in the constructor
+    Which method to use depends on which enums.CredentialType is passed along with the credentials in the constructor
     for gateway.CredentialDetails.
     """
 
@@ -95,10 +95,9 @@ class CredentialsBuilder:
 
     @staticmethod
     def _serialize(credentials_dict: Dict[str, Union[str, List[Dict[str, str]]]]) -> str:
-        # dump twice to get double quotes escaped properly
-        # remove spaces between object keys and values
+        # dump once to get double quotes escaped properly when converted to a request
+        # separators: remove spaces between object keys, values, and objects themselves
         # replace double backslashes with single slashes
-        # remove double quotes at start and end of str
         return json.dumps(credentials_dict, separators=(',', ':'))\
             .replace('\\\\','\\')
 

--- a/pypowerbi/utils.py
+++ b/pypowerbi/utils.py
@@ -99,8 +99,7 @@ class CredentialsBuilder:
         # remove spaces between object keys and values
         # replace double backslashes with single slashes
         # remove double quotes at start and end of str
-        return json.dumps(credentials_dict)\
-            .replace(r'": ', r'":')\
+        return json.dumps(credentials_dict, separators=(',', ':'))\
             .replace('\\\\','\\')
 
     @classmethod

--- a/pypowerbi/utils.py
+++ b/pypowerbi/utils.py
@@ -1,5 +1,8 @@
 # -*- coding: future_fstrings -*-
 import datetime
+import json
+from typing import Dict, Union, List
+from copy import deepcopy
 
 """
 This file contains helper and utility functions used elsewhere in the library.
@@ -24,6 +27,7 @@ def date_from_powerbi_str(dstr):
         # Fractional seconds are not zero padded in the API and will not be included at all if 0, thus the second format
         return datetime.datetime.strptime(dstr, _date_fmt_str2)
 
+
 def convert_datetime_fields(list_of_dicts, fields_to_convert):
     """
     Takes in a list of dictionaries and for each dictionary it converts all fields in fields_to_convert to
@@ -46,3 +50,100 @@ def convert_datetime_fields(list_of_dicts, fields_to_convert):
                 new_rec[field] = date_from_powerbi_str(new_rec[field])
 
     return new_list
+
+
+class CredentialsBuilder:
+    """
+    This class can be used to quickly generate credentials strings for use in a gateway.CredentialDetails object.
+    Which methods to use depends on Which enums.CredentialType is passed along with the credentials in the constructor
+    for gateway.CredentialDetails.
+    """
+
+    credential_data_key = "credentialData"
+    username_key = "username"
+    password_key = "password"
+    key_key = "key"
+    access_token_key = "accessToken"
+
+    ANONYMOUS_DICT_TEMPLATE = {credential_data_key: ""}
+    BASIC_DICT_TEMPLATE = {credential_data_key: [
+        {
+            "name": username_key,
+            "value": ""
+        },
+        {
+            "name": password_key,
+            "value": ""
+        }
+    ]}
+
+    KEY_DICT_TEMPLATE = {credential_data_key: [
+        {
+            "name": key_key,
+            "value": ""
+        }
+    ]}
+
+    OAUTH2_DICT_TEMPLATE = {credential_data_key: [
+        {
+            "name": access_token_key,
+            "value": ""
+        }
+    ]}
+
+    WINDOWS_DICT_TEMPLATE = BASIC_DICT_TEMPLATE
+
+    @staticmethod
+    def _serialize(credentials_dict: Dict[str, Union[str, List[Dict[str, str]]]]) -> str:
+        # dump twice to get double quotes escaped properly
+        # remove spaces between object keys and values
+        # replace double backslashes with single slashes
+        # remove double quotes at start and end of str
+        return json.dumps(json.dumps(credentials_dict))\
+            .replace(r'": ', r'":')\
+            .replace('\\\\','\\')\
+            [1:-1]
+
+    @classmethod
+    def get_anonymous_credentials(cls) -> str:
+        return cls._serialize(cls.ANONYMOUS_DICT_TEMPLATE)
+
+    @classmethod
+    def get_basic_credentials(cls, username: str, password: str) -> str:
+        # use deepcopy to avoid mutability issues
+        basic_credentials = deepcopy(cls.BASIC_DICT_TEMPLATE)
+        # set username
+        basic_credentials[cls.credential_data_key][0]["value"] = username
+        # set password
+        basic_credentials[cls.credential_data_key][1]["value"] = password
+
+        return cls._serialize(basic_credentials)
+
+    @classmethod
+    def get_key_credentials(cls, key: str) -> str:
+        # use deepcopy to avoid mutability issues
+        key_credentials = deepcopy(cls.KEY_DICT_TEMPLATE)
+        # set key
+        key_credentials[cls.credential_data_key][0]["value"] = key
+
+        return cls._serialize(key_credentials)
+
+    @classmethod
+    def get_o_auth_2_credentials(cls, access_token: str):
+        # use deepcopy to avoid mutability issues
+        o_auth_2_credentials = deepcopy(cls.OAUTH2_DICT_TEMPLATE)
+        # set access token
+        o_auth_2_credentials[cls.credential_data_key][0]["value"] = access_token
+
+        return cls._serialize(o_auth_2_credentials)
+
+    @classmethod
+    def get_windows_credentials(cls, username: str, password: str):
+        # use deepcopy to avoid mutability issues
+        windows_credentials = deepcopy(cls.WINDOWS_DICT_TEMPLATE)
+        # set username
+        windows_credentials[cls.credential_data_key][0]["value"] = username
+        # set password
+        windows_credentials[cls.credential_data_key][1]["value"] = password
+
+        return cls._serialize(windows_credentials)

--- a/pypowerbi/utils.py
+++ b/pypowerbi/utils.py
@@ -99,10 +99,9 @@ class CredentialsBuilder:
         # remove spaces between object keys and values
         # replace double backslashes with single slashes
         # remove double quotes at start and end of str
-        return json.dumps(json.dumps(credentials_dict))\
+        return json.dumps(credentials_dict)\
             .replace(r'": ', r'":')\
-            .replace('\\\\','\\')\
-            [1:-1]
+            .replace('\\\\','\\')
 
     @classmethod
     def get_anonymous_credentials(cls) -> str:

--- a/pypowerbi/utils.py
+++ b/pypowerbi/utils.py
@@ -1,8 +1,6 @@
 # -*- coding: future_fstrings -*-
 import datetime
-import json
-from typing import Dict, Union, List
-from copy import deepcopy
+
 
 """
 This file contains helper and utility functions used elsewhere in the library.
@@ -50,97 +48,3 @@ def convert_datetime_fields(list_of_dicts, fields_to_convert):
                 new_rec[field] = date_from_powerbi_str(new_rec[field])
 
     return new_list
-
-
-class CredentialsBuilder:
-    """
-    This class can be used to quickly generate credentials strings for use in a gateway.CredentialDetails object.
-    Which method to use depends on which enums.CredentialType is passed along with the credentials in the constructor
-    for gateway.CredentialDetails.
-    """
-
-    credential_data_key = "credentialData"
-    username_key = "username"
-    password_key = "password"
-    key_key = "key"
-    access_token_key = "accessToken"
-
-    ANONYMOUS_DICT_TEMPLATE = {credential_data_key: ""}
-    BASIC_DICT_TEMPLATE = {credential_data_key: [
-        {
-            "name": username_key,
-            "value": ""
-        },
-        {
-            "name": password_key,
-            "value": ""
-        }
-    ]}
-
-    KEY_DICT_TEMPLATE = {credential_data_key: [
-        {
-            "name": key_key,
-            "value": ""
-        }
-    ]}
-
-    OAUTH2_DICT_TEMPLATE = {credential_data_key: [
-        {
-            "name": access_token_key,
-            "value": ""
-        }
-    ]}
-
-    WINDOWS_DICT_TEMPLATE = BASIC_DICT_TEMPLATE
-
-    @staticmethod
-    def _serialize(credentials_dict: Dict[str, Union[str, List[Dict[str, str]]]]) -> str:
-        # dump once to get double quotes escaped properly when converted to a request
-        # separators: remove spaces between object keys, values, and objects themselves
-        # replace double backslashes with single slashes
-        return json.dumps(credentials_dict, separators=(',', ':'))\
-            .replace('\\\\','\\')
-
-    @classmethod
-    def get_anonymous_credentials(cls) -> str:
-        return cls._serialize(cls.ANONYMOUS_DICT_TEMPLATE)
-
-    @classmethod
-    def get_basic_credentials(cls, username: str, password: str) -> str:
-        # use deepcopy to avoid mutability issues
-        basic_credentials = deepcopy(cls.BASIC_DICT_TEMPLATE)
-        # set username
-        basic_credentials[cls.credential_data_key][0]["value"] = username
-        # set password
-        basic_credentials[cls.credential_data_key][1]["value"] = password
-
-        return cls._serialize(basic_credentials)
-
-    @classmethod
-    def get_key_credentials(cls, key: str) -> str:
-        # use deepcopy to avoid mutability issues
-        key_credentials = deepcopy(cls.KEY_DICT_TEMPLATE)
-        # set key
-        key_credentials[cls.credential_data_key][0]["value"] = key
-
-        return cls._serialize(key_credentials)
-
-    @classmethod
-    def get_o_auth_2_credentials(cls, access_token: str):
-        # use deepcopy to avoid mutability issues
-        o_auth_2_credentials = deepcopy(cls.OAUTH2_DICT_TEMPLATE)
-        # set access token
-        o_auth_2_credentials[cls.credential_data_key][0]["value"] = access_token
-
-        return cls._serialize(o_auth_2_credentials)
-
-    @classmethod
-    def get_windows_credentials(cls, username: str, password: str):
-        # use deepcopy to avoid mutability issues
-        windows_credentials = deepcopy(cls.WINDOWS_DICT_TEMPLATE)
-        # set username
-        windows_credentials[cls.credential_data_key][0]["value"] = username
-        # set password
-        windows_credentials[cls.credential_data_key][1]["value"] = password
-
-        return cls._serialize(windows_credentials)


### PR DESCRIPTION
Hi Chris,

Here's my third pull request for pypowerbi. This pull request adds a gateways and credentials module. The latter being needed in order to implement 'add datasources' in the former module.

**API methods**
The following api methods have been added:
- Get gateways
- Get gateway
- Get datasources
- Get datasource users
- Create datasource
- Delete datasource
- Add datasource user

**Models and Enums**
Additionally I have added the following models and enums to make the above methods work:
- GatewayPublicKey
- Gateway
- GatewayDatasource
- DatasourceUser
- DatasourceConnectionDetails
- CredentialDetails
- PublishDatasourceToGateway
- AnonymousCredentials
- BasicCredentials
- KeyCredentials
- OAuth2Credentials
- WindowsCredentials
- DatasourceUserAccessRight
- EncryptedConnection
- EncryptionAlgorithm
- PrivacyLevel

**Implementation Notes**
- As discussed through e-mail I have added typehints for this new module. Additionally, it again makes use of enums.
- I have moved all enums to dedicated module to make it easier to re-use them around the codebase.
- I have add a `Deserializable` abstract class in `base.py`, this simplified the json -> object conversion significantly. For a proof of concept implementation see `gateways.py`
- For the credentials classes I have added some unit tests, as I noticed the Gateway/REST API is quite strict when it comes to how to the strings are formatted.
- I was not able to run my unit tests on python 3.8 without adding the following lines in the root `__init__.py` due to an error from future_fstrings. I have removed these lines for this pull request:
```python
import future_fstrings

future_fstrings.register()
```
- Create Datasource in the current codebase will only work with Cloud Datasources, and not out-of-the-box with on-premise gateway datasources. For the latter to work the credentials json string (generated by one of te credentials classes' `to_json` method) provided to `CredentialDetails` will need to be encrypted with the Gateway public key. This process is described [here](https://docs.microsoft.com/en-us/power-bi/developer/automation/configure-credentials?tabs=sdk3). Porting that logic to python required a bit too much effort for this pull request.
- Add datasource user will only work when authenticating to the REST API with username/password instead of a service principal. In the latter case it will throw an HTTP 500 error with the general message: "An error has occurred". I have added a note about this in the appropriate docstring.