### PR TITLE
Add update refresh schedule

### DIFF
--- a/pypowerbi/dataset.py
+++ b/pypowerbi/dataset.py
@@ -1,5 +1,7 @@
 # -*- coding: future_fstrings -*-
 import json
+from enum import Enum
+from typing import List, Optional, Dict, Union
 
 
 class Dataset:
@@ -280,3 +282,82 @@ class Row:
 class RowEncoder(json.JSONEncoder):
     def default(self, o):
         return o.__dict__
+
+
+class ScheduleNotifyOption(Enum):
+    MAIL_ON_FAILURE = "MailOnFailure"
+    NO_NOTIFICATION = "NoNotification"
+
+
+class RefreshSchedule:
+    notify_option_key = 'NotifyOption'
+    days_key = 'days'
+    enabled_key = 'enabled'
+    local_time_zone_id_key = 'localTimeZoneId'
+    times_key = 'times'
+
+    def __init__(
+        self,
+        notify_option: Optional[ScheduleNotifyOption] = None,
+        days: Optional[List[str]] = None,
+        enabled: Optional[bool] = None,
+        local_time_zone_id: Optional[str] = None,
+        times: Optional[List[str]] = None
+    ):
+        """Constructs a RefreshSchedule object
+
+        :param notify_option: Notify on failure or not
+        :param days: Days to execute the refresh
+        :param enabled: Is the scheduled refresh enabled
+        :param local_time_zone_id: The id of the timezone to use. Follows the conventions described here:
+        https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo.id
+        :param times: Times to schedule the refresh on each specified day
+        """
+
+        self.notify_option = notify_option
+        self.days = days
+        self.enabled = enabled
+        self.local_time_zone_id = local_time_zone_id
+        self.times = times
+
+    def as_set_values_dict(self) -> Dict[str, Union[str, bool, List[str]]]:
+        set_values_dict = dict()
+
+        if self.notify_option:
+            set_values_dict[self.notify_option_key] = self.notify_option.value
+
+        if self.days:
+            set_values_dict[self.days_key] = self.days
+
+        if self.enabled is not None:
+            set_values_dict[self.enabled_key] = self.enabled
+
+        if self.local_time_zone_id:
+            set_values_dict[self.local_time_zone_id_key] = self.local_time_zone_id
+
+        if self.times:
+            set_values_dict[self.times_key] = self.times
+
+        return set_values_dict
+
+    def __repr__(self):
+        return f'<RefreshSchedule {str(self.as_set_values_dict())}>'
+
+
+class RefreshScheduleRequest:
+    value_key = "value"
+
+    def __init__(self, refresh_schedule: RefreshSchedule):
+        """Constructs an update Refresh Schedule request
+
+        :param refresh_schedule: The desired refresh schedule
+        """
+        self.refresh_schedule = refresh_schedule
+
+    def as_dict(self) -> Dict[str, Dict[str, Union[str, bool, List[str]]]]:
+        return {
+            self.value_key: self.refresh_schedule.as_set_values_dict()
+        }
+
+    def __repr__(self):
+        return f'<RefreshScheduleRequest {str(self.as_dict())}>'

--- a/pypowerbi/dataset.py
+++ b/pypowerbi/dataset.py
@@ -296,12 +296,23 @@ class RefreshSchedule:
     local_time_zone_id_key = 'localTimeZoneId'
     times_key = 'times'
 
+    @classmethod
+    def from_dict(cls, dictionary: Dict[str, Union[str, bool]]) -> 'RefreshSchedule':
+        notify_option_value = dictionary.get(cls.notify_option_key, None)
+        notify_option = ScheduleNotifyOption(notify_option_value) if notify_option_value else None
+        days = dictionary.get(cls.days_key, None)
+        enabled = dictionary.get(cls.enabled_key, None)
+        local_time_zone_id = dictionary.get(cls.local_time_zone_id_key, "")
+        times = dictionary.get(cls.times_key, None)
+
+        return cls(notify_option, days, enabled, local_time_zone_id, times)
+
     def __init__(
         self,
         notify_option: Optional[ScheduleNotifyOption] = None,
         days: Optional[List[str]] = None,
         enabled: Optional[bool] = None,
-        local_time_zone_id: Optional[str] = None,
+        local_time_zone_id: Optional[str] = "",
         times: Optional[List[str]] = None
     ):
         """Constructs a RefreshSchedule object

--- a/pypowerbi/datasets.py
+++ b/pypowerbi/datasets.py
@@ -495,6 +495,33 @@ class Datasets:
         if response.status_code != 200:
             raise HTTPError(f'Update refresh schedule request returned the following http error:{response.json()}')
 
+    def get_refresh_schedule(self, dataset_id: str, group_id: Optional[str] = None):
+        """Retrieves the refresh schedule for a given dataset and group id
+
+        :param dataset_id: The dataset id for which the refresh schedule should be retrieved
+        :param group_id:  The group in which the dataset resides. If None 'My Workspace' is used.
+        """
+        if group_id is None:
+            groups_part = '/'
+        else:
+            groups_part = f'/{self.groups_snippet}/{group_id}/'
+
+        # form the url
+        url = f'{self.base_url}{groups_part}/{self.datasets_snippet}/{dataset_id}/{self.refresh_schedule_snippet}'
+
+        # form the headers
+        headers = self.client.auth_header
+
+        # get the response
+        response = requests.get(url, headers=headers)
+
+        # 200 is the only successful code, raise an exception on any other response code
+        if response.status_code != 200:
+            raise HTTPError(f'Get refresh schedule request returned the following http error:{response.json()}')
+
+        return self.refresh_schedule_from_get_refresh_schedule_response(response)
+
+
     @classmethod
     def datasets_from_get_datasets_response(cls, response):
         """
@@ -526,3 +553,8 @@ class Datasets:
             tables.append(Table.from_dict(entry))
 
         return tables
+
+    @classmethod
+    def refresh_schedule_from_get_refresh_schedule_response(cls, response: requests.Response):
+        response_dict = json.loads(response.text)
+        return RefreshSchedule.from_dict(response_dict)

--- a/pypowerbi/datasets.py
+++ b/pypowerbi/datasets.py
@@ -17,6 +17,7 @@ class Datasets:
     set_parameters_snippet = 'Default.UpdateParameters'
     bind_gateway_snippet = 'Default.BindToGateway'
     refreshes_snippet = 'refreshes'
+    refresh_schedule_snippet = 'refreshSchedule'
 
     # json keys
     get_datasets_value_key = 'value'
@@ -459,6 +460,40 @@ class Datasets:
         refresh_data = convert_datetime_fields(refresh_data, time_fields)
 
         return refresh_data
+
+    def update_refresh_schedule(
+        self,
+        dataset_id: str,
+        refresh_schedule: RefreshSchedule,
+        group_id: Optional[str] = None
+    ):
+        """Updates the refresh schedule for a given dataset in a given workspace.
+
+        :param dataset_id: The dataset id
+        :param refresh_schedule: The updates for the refresh schedule. If a field remains None, no changes are made.
+        :param group_id: The workspace id of the workspace in which the dataset resides. If None, 'My Workspace' is
+        assumed.
+        """
+        if group_id is None:
+            groups_part = '/'
+        else:
+            groups_part = f'/{self.groups_snippet}/{group_id}/'
+
+        # form the url
+        url = f'{self.base_url}{groups_part}/{self.datasets_snippet}/{dataset_id}/{self.refresh_schedule_snippet}'
+
+        # form the headers
+        headers = self.client.auth_header
+
+        # form the body
+        body = RefreshScheduleRequest(refresh_schedule).as_dict()
+
+        # get the response
+        response = requests.patch(url, headers=headers, json=body)
+
+        # 200 is the only successful code, raise an exception on any other response code
+        if response.status_code != 200:
+            raise HTTPError(f'Update refresh schedule request returned the following http error:{response.json()}')
 
     @classmethod
     def datasets_from_get_datasets_response(cls, response):


### PR DESCRIPTION
Hi Chris,

Here's a third pull request that adds the following operations to the dataset module:
- Update refresh schedule
- Get refresh schedule

Code has already been tested in my own codebase.

Implementation notes:
- I have added the enums to the dataset module to prevent merge conflicts with #28 . When #28 gets merged we could consider moving the enums to the dedicated enums module.